### PR TITLE
Fix for "Error: Cannot find module ..." on SDK 4.0

### DIFF
--- a/app/src/js/app.js
+++ b/app/src/js/app.js
@@ -1,6 +1,6 @@
-Internet = require('internet'); // Communication with back-ends
-Watch    = require('watch');    // Communication with watch
-Geo      = require('geo');      // Geolocation
+Internet = require('./internet'); // Communication with back-ends
+Watch    = require('./watch');    // Communication with watch
+Geo      = require('./geo');      // Geolocation
 
 // Main events
 


### PR DESCRIPTION
# Issue

After I upgraded my Pebble Tool & SDK (`pebble --version` gives `Pebble Tool v4.4 (active SDK: v4.0)`), the app would freeze on the splash screen. The logs:

```
[23:29:13] pkjs> TO Transit:325 JavaScript Error:
Error: Cannot find module 'internet'
    at Object.loader.require (loader.js:67:11)
    at require (loader.js:55:48)
    at Object.loader (src/js/app.js:1:12)
    at _require (loader.js:58:10)
    at Object.loader.require (loader.js:70:10)
    at build/js/message_keys.json:42:14
    at build/js/message_keys.json:43:5
    at build/js/message_keys.json:44:3
```

# Fix
Not sure why, but prefixing the required module with the current directory (e.g., replacing `require('foo')` with `require('./foo')`) fixes the issue.

I *did* notice that a new version of Node.js was installed as part of the upgrade process, but I'd not expect it to have an effect once the .js is fully concatenated (but I did not dig too much in how `require` does its magic anyway).