### PR TITLE
Supress blue night buses during the day

### DIFF
--- a/server/app/models/route.rb
+++ b/server/app/models/route.rb
@@ -1,3 +1,19 @@
 class Route < ApplicationRecord
   has_many :directions
+
+  scope :for_current_time, -> {
+    blue_night_time? ? all : where("routes.tag not like '3__'")
+  }
+
+  private
+
+  def self.blue_night_time?
+    # Blue night runs between 1:30 and 5:00. We'll give it 30 min of leeway
+    # (cf.: http://www.ttc.ca/images/fixedImages/TTC-bluenight.pdf)
+    now_in_toronto.between?('01:00', '05:30')
+  end
+
+  def self.now_in_toronto
+    Time.find_zone("America/Toronto").now.strftime('%H:%M')
+  end
 end

--- a/server/app/models/stop.rb
+++ b/server/app/models/stop.rb
@@ -11,6 +11,7 @@ class Stop < ApplicationRecord
 
   scope :with_routes_and_directions_grouped_by_address, -> {
     joins(directions: :route)
+      .merge(Route.for_current_time)
       .select('stops.title      stop,     ' \
               'routes.title     route,    ' \
               'directions.title direction,' \

--- a/server/test/fixtures/routes.yml
+++ b/server/test/fixtures/routes.yml
@@ -1,9 +1,11 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+nighttime:
+  tag: 315
+  title: nighttime route
 
-one:
-  tag: 
-  title: MyString
+daytime:
+  tag: 666
+  title: daytime route
 
-two:
-  tag: 
-  title: MyString
+daytime_with_two_digits:
+  tag: 33
+  title: another daytime route

--- a/server/test/models/route_test.rb
+++ b/server/test/models/route_test.rb
@@ -1,7 +1,31 @@
 require 'test_helper'
 
 class RouteTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "#for_current_time supresses 3xx routes before 1:00AM and after 5:30AM" do
+    %w(0:00 0:59 5:31 9:00 12:00 15:25 23:39).each do |time|
+      hour, minute = time.split(':').map(&:to_i)
+      Timecop.travel(today_in_toronto_at(hour, minute)) do
+        routes = Route.for_current_time
+        assert_equal %w(33 666), routes.map(&:tag).sort,
+          "3xx route should have been suppressed at #{time}"
+      end
+    end
+  end
+
+  test "#for_current_time includes 3xx between 1:00AM and 5:30AM" do
+    %w(1:00 1:30 4:00 5:00 5:30).each do |time|
+      hour, minute = time.split(':').map(&:to_i)
+      Timecop.travel(today_in_toronto_at(hour, minute)) do
+        routes = Route.for_current_time
+        assert_equal %w(315 33 666), routes.map(&:tag).sort,
+          "3xx route should have been included at #{time}"
+      end
+    end
+  end
+
+  private
+
+  def today_in_toronto_at(hour, minute)
+    Time.find_zone("America/Toronto").local(2016, 1, 1, hour, minute)
+  end
 end


### PR DESCRIPTION
I'm not sure yet whether which routes stop during the night and which don't, but Blue Night has a [well documented](http://www.ttc.ca/images/fixedImages/TTC-bluenight.pdf) schedule, so for now I'm just removing the Blue Night routes outside of it.

Closes #5 