### PR TITLE
Add support for new Pebble models (flint, gabbro)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,9 @@
       "basalt",
       "chalk",
       "diorite",
-      "emery"
+      "emery",
+      "flint",
+      "gabbro"
     ],
     "enableMultiJS": true,
     "capabilities": [

--- a/app/src/layers/routes.c
+++ b/app/src/layers/routes.c
@@ -52,7 +52,7 @@ static uint16_t menu_get_num_rows_callback(MenuLayer *menu_layer, uint16_t secti
 }
 
 static int16_t menu_get_header_height_callback(MenuLayer *menu_layer, uint16_t section_index, void *data) {
-  return 16; //MENU_CELL_BASIC_HEADER_HEIGHT;
+  return MENU_CELL_BASIC_HEADER_HEIGHT;
 }
 
 static void menu_draw_header_callback(GContext* ctx, const Layer *cell_layer, uint16_t section_index, void *data) {

--- a/app/wscript
+++ b/app/wscript
@@ -1,0 +1,48 @@
+#
+# This file is the default set of rules to compile a Pebble project.
+#
+# Feel free to customize this to your needs.
+#
+
+import os.path
+
+top = '.'
+out = 'build'
+
+
+def options(ctx):
+    ctx.load('pebble_sdk')
+
+
+def configure(ctx):
+    """
+    This method is used to configure your build.
+    ctx.load(`pebble_sdk`) automatically configures a build for each valid platform in `targetPlatforms`.
+    Platform-specific configuration: add your change after calling ctx.load('pebble_sdk') and make sure to set the
+    correct environment first.
+    Universal configuration: add your change prior to calling ctx.load('pebble_sdk').
+    """
+    ctx.load('pebble_sdk')
+
+
+def build(ctx):
+    ctx.load('pebble_sdk')
+
+    build_worker = os.path.exists('worker_src')
+    binaries = []
+
+    for p in ctx.env.TARGET_PLATFORMS:
+        ctx.set_env(ctx.all_envs[p])
+        ctx.set_group(ctx.env.PLATFORM_NAME)
+        app_elf = '{}/pebble-app.elf'.format(ctx.env.BUILD_DIR)
+        ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'), target=app_elf)
+
+        if build_worker:
+            worker_elf = '{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
+            binaries.append({'platform': p, 'app_elf': app_elf, 'worker_elf': worker_elf})
+            ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/**/*.c'), target=worker_elf)
+        else:
+            binaries.append({'platform': p, 'app_elf': app_elf})
+
+    ctx.set_group('bundle')
+    ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob(['src/js/**/*.js', 'src/js/**/*.json']), js_entry_file='src/js/app.js')


### PR DESCRIPTION
## Summary

- Add the Pebble 2 Duo (flint) and Pebble Round 2 (gabbro) to target platforms, so the app builds natively for the new rePebble hardware
- Fix the build, which was accidentally broken in #68 (the SDK requires `wscript` to be present)

## Test plan

- [x] `pebble build` produces binaries for all 7 platforms
- [x] Tested on basalt, chalk, flint and gabbro emulators